### PR TITLE
feat: twitter 記法を追加

### DIFF
--- a/services/blog/templates/wrapper.html
+++ b/services/blog/templates/wrapper.html
@@ -25,6 +25,7 @@
 
 <body>
   {{block "body" .}}{{end}}
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </body>
 
 </html>

--- a/services/renderer-ts/Dockerfile
+++ b/services/renderer-ts/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14-alpine AS builder
 
 WORKDIR /services/renderer-ts
 COPY package.json yarn.lock ./
+RUN apk --update add git
 RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn/v6 \
   yarn install --frozen-lockfile
 COPY . .

--- a/services/renderer-ts/package.json
+++ b/services/renderer-ts/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
-    "@progfay/scrapbox-parser": "^7.1.0",
+    "@progfay/scrapbox-parser": "https://github.com/neneka/scrapbox-parser.git#chore/add-original-nota",
     "google-protobuf": "^3.17.3",
     "grpc-js-health-check": "^1.0.2",
     "react": "^17.0.2",

--- a/services/renderer-ts/src/parser/nodeRenderer.tsx
+++ b/services/renderer-ts/src/parser/nodeRenderer.tsx
@@ -125,6 +125,13 @@ export const LineNodeRenderer: React.VFC<{ node: Node; _key: string | number }> 
           ))}
         </b>
       );
+    case "twitter":
+      return (
+        <blockquote className="twitter-tweet">
+          <p lang="ja" dir="ltr"></p>ツイート展開中…
+          <a href={`https://twitter.com/twitter/status/${node.id}`}></a>
+        </blockquote>
+      );
     default:
       return <p>not supported ({node?.type})</p>;
   }

--- a/services/renderer-ts/yarn.lock
+++ b/services/renderer-ts/yarn.lock
@@ -591,10 +591,9 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@progfay/scrapbox-parser@^7.1.0":
+"@progfay/scrapbox-parser@https://github.com/neneka/scrapbox-parser.git#chore/add-original-nota":
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@progfay/scrapbox-parser/-/scrapbox-parser-7.1.0.tgz#835a1e1939fd30ca500f5da03b1b2bf5ec407240"
-  integrity sha512-jZXEOGf9KZien4YAec9WG58Vy/6XA6ARac4NSGX2Msd1M3nSChnDgZL4ny0oNZvV1LDqPCdDYcTt5AfZEk+xmQ==
+  resolved "https://github.com/neneka/scrapbox-parser.git#2f59af42c92f225a73bbd2cae613ab295814c11a"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
resolves #6 

`[🐣 https://twitter.com/motemen/status/1428235436938317828]`

![image](https://user-images.githubusercontent.com/7887955/130043898-7714e5af-d26b-42c3-a2a0-678085b24700.png)

毎回ひよこって打つ必要があるのは本当に面倒だが、Twitterを引用するにはこれぐらいの覚悟が必要